### PR TITLE
Builder may returns null if there is no specifications

### DIFF
--- a/src/main/java/com/github/wenhao/jpa/PredicateBuilder.java
+++ b/src/main/java/com/github/wenhao/jpa/PredicateBuilder.java
@@ -145,4 +145,8 @@ public class PredicateBuilder<T> {
             }
         };
     }
+
+    public Specification<T> buildOrNullIfEmpty() {
+        return specifications.isEmpty() ? null : build();
+    }
 }


### PR DESCRIPTION
https://github.com/spring-projects/spring-data-jpa/blob/master/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java#L674

If specification is null it will return all items.

```java
public Page<File> search(@NotNull SearchFileCommand command, Pageable pageable) {

    Specification<File> specification = Specifications.<File>or()
        .eq(isNotBlank(command.getName()), "name", command.getName())
        .eq(isNotBlank(command.getType()), "type", command.getType())
        .buildOrNullIfEmpty();

    return repository.findAll(specification, pageable);
}
```